### PR TITLE
add support for rendering comments

### DIFF
--- a/components/gist-document.js
+++ b/components/gist-document.js
@@ -1,8 +1,11 @@
+import relativeTime from 'dayjs/plugin/relativeTime';
 import { findMarkdownFile } from '../lib/utility';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import Link from 'next/link';
 import dayjs from 'dayjs';
+
+dayjs.extend(relativeTime);
 
 function GistMeta({ author, updatedAt, gistURL }) {
   const { login, avatar_url, html_url } = author;
@@ -40,7 +43,59 @@ function UnsupportedGist() {
   );
 }
 
-export default function GistDocument({ gistData, commentData, showMeta = true }) {
+function Comment({ body, createdAt, username, avatarURL, authorURL, commentURL }) {
+  return (
+    <div className={'comment'}>
+      <div className={'comment-header'}>
+        <img src={avatarURL} alt="author's avatar" />
+        <a className={'comment-author'} href={authorURL}>{username}</a>
+      </div>
+      <div className={'comment-body'}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{body}</ReactMarkdown>
+      </div>
+      <a className={'comment-date'} href={commentURL} title={dayjs(createdAt).format('MMM D, YYYY h:mmA')}>{dayjs(createdAt).fromNow()}</a>
+    </div>
+  )
+}
+
+function GistComments({ gistData, commentData }) {
+  return (
+    <div className={'comments'}>
+      {
+        commentData && <h2>Comments ({commentData.length})</h2>
+      }
+      {
+        commentData && (
+          <ul className={'comments-list'}>
+            {commentData.map(comment => 
+              <Comment
+                body={comment.body}
+                createdAt={comment.created_at}
+                username={comment.user.login}
+                avatarURL={comment.user.avatar_url}
+                authorURL={comment.user.html_url}
+                // This is an undocumented way to link directly to a gist comment
+                commentURL={`${gistData.html_url}#gistcomment-${comment.id}`}
+              />
+            )}
+          </ul>
+        )
+      }
+      <div className={'comments-cta'}>
+        <a href={gistData.html_url} target="_blank">
+          Comment on Github
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default function GistDocument({
+  gistData,
+  commentData,
+  showMeta = true,
+  showComments = true
+}) {
   const files = gistData.files || {};
   const filenames = Object.keys(files);
   const markdownFile = findMarkdownFile(filenames);
@@ -55,41 +110,18 @@ export default function GistDocument({ gistData, commentData, showMeta = true })
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
       </div>
       {
-        showMeta && 
-        <GistMeta
-          author={gistData.owner}
-          updatedAt={gistData.updated_at}
-          gistURL={gistData.html_url}
-        />
+        showMeta &&  <GistMeta
+                        author={gistData.owner}
+                        updatedAt={gistData.updated_at}
+                        gistURL={gistData.html_url}
+                      />
       }
-      {/*
       {
-        commentData && commentData.length ?
-        (
-          <div>
-            <h2>Comments</h2>
-            <ul className={'comments'}>
-              {commentData.map(comment => 
-                <Comment
-                  body={comment.body}
-                  createdAt={comment.created_at}
-                  username={comment.user.login}
-                  avatarUrl={comment.user.avatar_url}
-                />
-              )}
-            </ul>
-            <div className={'comments-cta'}>
-              <a href={gistData.html_url} target="_blank">
-                Comment on Github
-              </a>
-            </div>
-          </div>
-        ) :
-        commentData && !commentData.length ?
-        null :
-        <div>comments loading...</div>
+        showComments && <GistComments
+                          commentData={commentData}
+                          gistData={gistData}
+                        />
       }
-      */}
     </div>
   );
 }

--- a/pages/[gist_id].js
+++ b/pages/[gist_id].js
@@ -30,10 +30,10 @@ function Page() {
   const router = useRouter();
   const { gist_id } = router.query;
   const gistUrl = `${constants.GITHUB_API_BASE_URL}/gists/${gist_id}`;
-  // const gistCommentsUrl = `${constants.GITHUB_API_BASE_URL}/gists/${gist_id}/comments`;
+  const gistCommentsUrl = `${constants.GITHUB_API_BASE_URL}/gists/${gist_id}/comments`;
 
   const { data: gistData, error: gistError } = useSWR(gist_id ? gistUrl : null, fetcher);
-  // const { data: commentData, error: commentError } = useSWR(gistData ? gistCommentsUrl : null, fetcher);
+  const { data: commentData, error: commentError } = useSWR(gistData && gistData.comments > 0 ? gistCommentsUrl : null, fetcher);
 
   const title = gistData ? `${gistData.description} | Gistdoc` : "Gistdoc";
   const description = gistData ? gistData.description : "Gistdoc"; 
@@ -66,7 +66,7 @@ function Page() {
             <GistDocumentSkeleton/>
           ) : (
           // Gist
-            <GistDocument gistData={gistData} />
+            <GistDocument gistData={gistData} commentData={commentData} />
           )
         }
       </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -56,7 +56,7 @@ export default function Home() {
       </div>
       {
         gistData ? (
-          <GistDocument gistData={gistData} showMeta={false} />
+          <GistDocument gistData={gistData} showMeta={false} showComments={false} />
         ) : (
           <GistDocumentSkeleton />
         )

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -106,8 +106,12 @@ pre > code {
   margin: 0 auto;
 }
 
+.comments-list {
+  padding: 0;
+}
+
 .comments {
-  margin: 0;
+  margin: 4rem 0 0 0;
   padding: 0;
 }
 
@@ -115,10 +119,7 @@ pre > code {
   list-style-type: none;
   border-bottom: 1px solid #f7f7f7;
   margin-bottom: 1rem;
-}
-
-.comment-body {
-  padding: 0 1rem 0 calc(36px + .5rem);
+  padding:  1rem 0;
 }
 
 .comment-header {
@@ -126,29 +127,52 @@ pre > code {
   display: flex;
   -moz-box-align: center;
   align-items: center;
-  color: #888;
+}
+
+.content .comments > h2:first-child {
+  font-size:  1.5rem;
+  font-weight: 500;
+  text-align: left;
+}
+
+.comment-body p > img {
+  margin:  0;
+}
+
+.comment-date {
+    font-size: .9rem;
+    color: #767676;
 }
 
 .comment-header img {
-  max-width: 36px;
+  max-width: 28px;
   border-radius: 100%;
   margin-right: .5rem;
 }
 
-.comment-header span {
+.comment-author {
   margin-right: .5rem;
+  font-size: .9rem;
+  color: #888;
+}
+
+.comments-cta a {
+  display: block;
+  padding:  1rem;
+  text-align: center;
+  color: #999;
+  background: #f7f7f7;
+  border-radius: 4px;
+  width:  100%;
+  margin: 0 auto;
+  transition: 200ms ease all;
   font-size: .9rem;
 }
 
-.comments-cta {
-  display: block;
-  padding: 0.5rem 1rem;
-  text-align: center;
-  color: #555;
-  background: #f7f7f7;
-  border-radius: 4px;
-  max-width: 250px;
-  margin: 0 auto;
+.comments-cta a:hover {
+  color: #222;
+  background: #eee;
+  text-decoration: none;
 }
 
 .footer {


### PR DESCRIPTION
Adds comments to gistdoc documents.

If a gist has comments they will be rendered at the bottom of the gistdoc page along with a link to comment on GitHub.

[This](https://gistdoc.com/b8862b789ac677c39755d1aa2131bca1) is an example gistdoc page with comments.