### PR TITLE
remove plausible analytics

### DIFF
--- a/pages/[gist_id].js
+++ b/pages/[gist_id].js
@@ -46,7 +46,6 @@ function Page() {
         <meta name="description" content={description} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#1d1d1d" />
-        <script defer data-domain="gistdoc.com" src="https://plausible.io/js/plausible.js"></script>
         {
           gistData?.public === false && <meta name="robots" content="noindex"/>
         }

--- a/pages/index.js
+++ b/pages/index.js
@@ -19,7 +19,6 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Gistdoc</title>
         <link rel="preconnect" href="https://user-images.githubusercontent.com/" />
-        <script defer data-domain="gistdoc.com" src="https://plausible.io/js/plausible.js"></script>
 
         <meta name="title" content="Gistdoc" />
         <meta name="description" content="Quickly view GitHub markdown gists as simple blog-style pages" />


### PR DESCRIPTION
This PR removes [Plausible Analytics](https://plausible.io/).

Plausible is a privacy-focused analytics service that tracks pageviews without cookies. I originally added Plausible as a simple way to see whether the site got any traffic. While it accomplishes that goal, I've reconsidered the need and prefer not to track anything.

The main reason I don't like tracking pageviews for this application is that it would track the _path_ as part of a pageview. While Secret gists aren't intended to be truly "private," I don't like the idea of a pageview including the id of a secret gist.

I wouldn't appreciate this as a user of Gistdoc and so I prefer to cut analytics entirely.